### PR TITLE
Feat/add cookie option

### DIFF
--- a/.changeset/lucky-horses-applaud.md
+++ b/.changeset/lucky-horses-applaud.md
@@ -1,0 +1,5 @@
+---
+"chromascope": minor
+---
+
+Add optional cookie option

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Options:
   -e, --element <selector>     Diff only the element with the given selector
   -f, --full-page              Take a full page screenshot
   -v, --verbose                Show more output
+  -c, --cookie <cookie>        Add one or more cookies to the context. Format: key=value;key2=value2
   -s, --save-diff              Save generated diff as png
   -t, --threshold <threshold>  Set the threshold for the diff (default: 0.2)
   -f, --folder <folder>        Set the base folder for chromascope runs (default: chromascope-runs)

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -1,6 +1,7 @@
 import { ChromascopeContext } from "../context";
 import logger from "../lib/logger";
 import { createSpinner } from "../lib/spinner";
+import { parseCookieOptions } from "../lib/utils";
 import { Browser, chromium, firefox, webkit } from "@playwright/test";
 import fs from "fs";
 import pixelmatch from "pixelmatch";
@@ -95,6 +96,11 @@ const captureBrowserScreenshot = async (link: string, browser: Browser, ctx: Chr
   const type = browser.browserType();
   const name = type.name();
   const page = await context.newPage();
+  const cookiesToAdd = parseCookieOptions(ctx.options.cookie, link);
+  if (cookiesToAdd.length > 0) {
+    logger.debug(`Adding cookies to ${name} context: ${JSON.stringify(cookiesToAdd)}`);
+    context.addCookies(parseCookieOptions(ctx.options.cookie, link));
+  }
   await page.goto(link);
   const path = ctx.options.saveDiff ? `${ctx.runFolder}/${name}.png` : undefined;
   logger.debug(`Saving ${name} screenshot to ${path}`);

--- a/src/context.ts
+++ b/src/context.ts
@@ -7,6 +7,7 @@ export type ChromascopeOptions = {
   saveDiff: boolean;
   element: string;
   fullPage: boolean;
+  cookie: string;
 };
 
 export type ChromascopeContext = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ cli
   .option("-e, --element <selector>", "Diff only the element with the given selector")
   .option("-f, --full-page", "Take a full page screenshot")
   .option("-v, --verbose", "Show more output")
+  .option("-c, --cookie <cookie>", "Add one or more cookies to the context. Format: key=value;key2=value2")
   .option("-s, --save-diff", "Save generated diff as png")
   .option("-t, --threshold <threshold>", "Set the threshold for the diff", {
     default: 0.2,

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,7 +1,7 @@
-import { isUrl } from "./utils";
+import { isUrl, parseCookieOptions } from "./utils";
 import { describe, expect, it } from "vitest";
 
-describe("utils", () => {
+describe("isUrl", () => {
   it("should allow localhost urls", () => {
     const url = "http://localhost:3000";
     expect(isUrl(url)).toBe(true);
@@ -33,5 +33,43 @@ describe("utils", () => {
   it("should not allow urls without a domain", () => {
     const url = "https://";
     expect(isUrl(url)).toBe(false);
+  });
+});
+
+describe("parseCookieOptions", () => {
+  const url = "https://example.com";
+  it("should parse cookies", () => {
+    const cookies = "foo=bar;bar=baz";
+    expect(parseCookieOptions(cookies, url)).toEqual([
+      { name: "foo", value: "bar", url },
+      { name: "bar", value: "baz", url },
+    ]);
+  });
+  it("should parse single cookie", () => {
+    const cookies = "foo=bar";
+    expect(parseCookieOptions(cookies, url)).toEqual([{ name: "foo", value: "bar", url }]);
+  });
+  it("should parse cookies with spaces", () => {
+    const cookies = "foo = bar; bar = baz";
+    expect(parseCookieOptions(cookies, url)).toEqual([
+      { name: "foo", value: "bar", url },
+      { name: "bar", value: "baz", url },
+    ]);
+  });
+  it("should parse an empty string without throwing", () => {
+    const cookies = "";
+    expect(parseCookieOptions(cookies, url)).toEqual([]);
+  });
+  it("should parse a value with an equals sign", () => {
+    const cookies =
+      "CookieConsent={stamp:%27WxrO46wiM4iF3wmVF00zO/M3+azPktEBeauYQCSr2t2oLxf8s+u42A==%27%2Cnecessary:true%2Cpreferences:true%2Cstatistics:true%2Cmarketing:true%2Cmethod:%27explicit%27%2Cver:2%2Cutc:1677699545253%2Cregion:%27no%27}";
+    expect(parseCookieOptions(cookies, url)).toEqual([
+      {
+        name: "CookieConsent",
+        value:
+          "{stamp:%27WxrO46wiM4iF3wmVF00zO/M3+azPktEBeauYQCSr2t2oLxf8s+u42A==%27%2Cnecessary:true%2Cpreferences:true%2Cstatistics:true%2Cmarketing:true%2Cmethod:%27explicit%27%2Cver:2%2Cutc:1677699545253%2Cregion:%27no%27}",
+        url,
+      },
+    ]);
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,3 +2,15 @@ const urlRegex =
   /^(?:(?:https?|ftp):\/\/)?(?:localhost|\S+(?:\.[^\s.]+)+|\[?[0-9a-fA-F:]+\]?)(?::\d+)?(?:\/[\w#!:.?+=&%@!\-\/]*)?(?:\?[\w&=]+)?$/i;
 
 export const isUrl = (url: string) => urlRegex.test(url);
+
+export const parseCookieOptions = (cookies: string, url: string) => {
+  const parsedCookies: Array<{ name: string; value: string; url: string }> = [];
+  cookies.split(";").forEach((cookie) => {
+    if (!cookie) return;
+    const indexOfEquals = cookie.indexOf("=");
+    const key = cookie.slice(0, indexOfEquals);
+    const values = cookie.slice(indexOfEquals + 1);
+    parsedCookies.push({ name: key.trim(), value: values.trim(), url });
+  });
+  return parsedCookies;
+};


### PR DESCRIPTION
Add `--cookie` option, aliased to `-c`.

Adds a cookie or multiple cookies, separated by semi-colon, to the browser context.