### PR TITLE
Install browser deps

### DIFF
--- a/.changeset/wise-beers-fix.md
+++ b/.changeset/wise-beers-fix.md
@@ -1,0 +1,5 @@
+---
+"chromascope": patch
+---
+
+Run playwright install as a post install script

--- a/package.json
+++ b/package.json
@@ -5,14 +5,8 @@
   "license": "ISC",
   "description": "Visually compare the same URL or DOM element in different browsers, from the safety of the command line.",
   "keywords": [
-    "diff",
-    "playwright",
-    "cross-browser testing",
-    "visual regression testing",
-    "pixelmatch",
-    "UI testing",
-    "screenshot comparison",
-    "cli"
+    "diff", "playwright", "cross-browser testing", "visual regression testing", "pixelmatch", "UI testing",
+    "screenshot comparison", "cli"
   ],
   "repository": {
     "type": "git",
@@ -40,7 +34,8 @@
     "format": "rome format ./src --write",
     "test": "vitest run",
     "ci": "pnpm run lint && pnpm run test && pnpm run build",
-    "release": "pnpm run ci && changeset publish"
+    "release": "pnpm run ci && changeset publish",
+    "postinstall": "echo 'Installing required playwright browsers...' && npx playwright install chromium webkit firefox"
   },
   "peerDependencies": {
     "playwright-core": "^1"

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -116,7 +116,9 @@ const diffScreenshots = async (
   ctx: ChromascopeContext,
 ) => {
   if (!screenshotOne || !screenshotTwo) {
-    throw new Error("Screenshot buffer cannot be null");
+    throw new Error(
+      "One or more screenshot buffer is null. Make sure all browsers are installed by running `npx playwright install chromium webkit firefox`.",
+    );
   }
   let png1: ImageWithMetadata = PNG.sync.read(screenshotOne);
   let png2: ImageWithMetadata = PNG.sync.read(screenshotTwo);

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ cli.version(version);
     await cli.runMatchedCommand();
   } catch (error) {
     spinner.fail("Failed");
-    logger.error("Error running command: ", error);
+    logger.error(error);
     process.exit(1);
   }
 })();


### PR DESCRIPTION
Chromascope would fail if playwright browsers aren't already installed.
* Add postinstall script to run the `playwright install` command
* Add clearer error message when screenshot buffer is null, suggesting to run playwright install